### PR TITLE
Remove unexistant flag in macos

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ function install_launcher {
 }
 
 function install_jdtls {
-    EQUINOX_LAUNCHER=`find "$JDTLS_ROOT/plugins" -nowarn -type f -name 'org.eclipse.equinox.launcher_*' 2> /dev/null`
+    EQUINOX_LAUNCHER=`find "$JDTLS_ROOT/plugins" -type f -name 'org.eclipse.equinox.launcher_*' 2> /dev/null`
     if [[ -f "EQUINOX_LAUNCHER" ]]; then
         echo "ERROR: JDTLS installation found at $JDTLS_ROOT" >> /dev/stderr
         exit 1
@@ -37,7 +37,7 @@ function install_jdtls {
     chmod -R 777 "$JDTLS_ROOT"
 
     # Installation check
-    EQUINOX_LAUNCHER=`find "$JDTLS_ROOT/plugins" -nowarn -type f -name 'org.eclipse.equinox.launcher_*' 2> /dev/null`
+    EQUINOX_LAUNCHER=`find "$JDTLS_ROOT/plugins" -type f -name 'org.eclipse.equinox.launcher_*' 2> /dev/null`
     if ! [[ -f "$EQUINOX_LAUNCHER" ]]; then
         echo 'ERROR: JDTLS installation failure' > /dev/stderr
         exit 1

--- a/jdtls-launcher.sh
+++ b/jdtls-launcher.sh
@@ -7,7 +7,7 @@ WORKSPACE="$HOME/workspace"
 
 case "$1" in
     -v|--version)
-        echo "jdtls-launcher version v1.0.0"
+        echo "jdtls-launcher version v1.0.1"
         exit 0
         ;;
 esac


### PR DESCRIPTION
It seems that the `-nowarn` flag in find doesn't exist in the macos version of find, making the finding fail thus script assumes installation failed.

Closes #1 