### PR TITLE
fix: use `--output` instead of shell redirection for curl

### DIFF
--- a/jdtls-launcher.sh
+++ b/jdtls-launcher.sh
@@ -54,7 +54,7 @@ function install_lombok {
         return 0
     fi
 
-    curl "https://projectlombok.org/downloads/lombok.jar" > "$LOMBOK"
+    curl "https://projectlombok.org/downloads/lombok.jar" --output "$LOMBOK"
 
     if [ ! -f "$LOMBOK" ]; then
         echo ' Lombok installation failure' > /dev/stderr
@@ -81,7 +81,7 @@ function jdtls_install {
     mkdir -p "$JDTLS_ROOT"
     cd "$JDTLS_ROOT"
 
-    curl -L "http://download.eclipse.org/jdtls/snapshots/$LATEST" > "$LATEST"
+    curl -L "http://download.eclipse.org/jdtls/snapshots/$LATEST" --output "$LATEST"
     tar -xf "$LATEST"
     rm "$LATEST"
     chmod -R 755 "$JDTLS_ROOT"


### PR DESCRIPTION
**Problem**

When I run the install script I get an error when trying to uncompress the jdtls download.
Afterwards some of the jar files are missing in ~/.local/opt/jdtls-launcher/jdtls/plugins/

<details>
<summary>Full logs</summary>
<pre>
[cfosli]$ curl https://raw.githubusercontent.com/eruizc-dev/jdtls-launcher/master/install.sh | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1474  100  1474    0     0  13493      0 --:--:-- --:--:-- --:--:-- 13648
INFO: Downloading JDTLS-LAUNCHER
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  5089    0  5089    0     0   7940      0 --:--:-- --:--:-- --:--:--     0

INFO: Extracting JDTLS-LAUNCHER
INFO: Creating symlink at /home/cfosli/.local/bin/jdtls
Installing jdtls...
jdt-language-server-1.12.0-202205230356 is going to be installed
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   162  100   162    0     0    618      0 --:--:-- --:--:-- --:--:--   620
100 45.8M  100 45.8M    0     0  7339k      0  0:00:06  0:00:06 --:--:-- 9935k

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
Installing lombok...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1925k  100 1925k    0     0  1405k      0  0:00:01  0:00:01 --:--:-- 1404k
Lombok installation succesfull
JDTLS installation succesfull
INFO: Installation successful
INFO: Ensure /home/cfosli/.local/bin is in path
</pre>
</details>

**Solution**

It works fine if I change shell redirection `>` to use the `--output` option in curl.
I'm assuming the file content contained some special character that my shell interpreted wrongly, or something like that.