### PR TITLE
jdtls-launcher.sh: respect user XDG settings.

### DIFF
--- a/jdtls-launcher.sh
+++ b/jdtls-launcher.sh
@@ -10,7 +10,7 @@ SCRIPT_VERSION='v1.1.6'
 SCRIPT_ROOT=`dirname $(realpath "$0")`
 
 JDTLS_ROOT="$SCRIPT_ROOT/jdtls"
-JDTLS_WORKSPACE="$HOME/.cache/jdtls-workspace"
+JDTLS_WORKSPACE="${XDG_CACHE_HOME:-$HOME/.cache}/jdtls-workspace"
 JDTLS_CORE=`find "$JDTLS_ROOT/plugins" -type f -name 'org.eclipse.jdt.ls.core_*' 2> /dev/null`
 JDTLS_EQUINOX_LAUNCHER=`find "$JDTLS_ROOT/plugins" -type f -name 'org.eclipse.equinox.launcher_*' 2> /dev/null`
 JDTLS_BACKUP_ROOT="$SCRIPT_ROOT/jdtls-old"


### PR DESCRIPTION
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html Follow the users XDG Base Directory Specification, create the jdtls-workspace dir at: ${XDG_CACHE_HOME}/jdtls-workspace

If $XDG_CACHE_HOME is not set, use the default:
"$HOME/.cache/jdtls-workspace"
(Kinda) related to #14 