### PR TITLE
feature: allow downgrade / install specific version

### DIFF
--- a/jdtls-launcher.sh
+++ b/jdtls-launcher.sh
@@ -34,13 +34,13 @@ function print_version {
 function print_help {
     echo 'jdtls-launcher: install and launch jdtls with a single command'
     echo 'available options:'
-    echo '  -v | --version      prints version of all components'
-    echo '  -h | --help         prints this menu'
-    echo '  -i | --install      install jdtls if not installed'
-    echo '  --uninstall         uninstall jdtls if installed'
-    echo '  --update            uninstall and install jdtls creating a backup and restoring in case of failure'
-    echo '  --backup            creates a backup of the current jdtls installation'
-    echo '  --restore           restores the jdtls backup'
+    echo '  -v | --version            prints version of all components'
+    echo '  -h | --help               prints this menu'
+    echo '  -i | --install [version]  install jdtls if not installed. optionally specify a version like 1.15.0'
+    echo '  --uninstall               uninstall jdtls if installed'
+    echo '  --update                  uninstall and install jdtls creating a backup and restoring in case of failure'
+    echo '  --backup                  creates a backup of the current jdtls installation'
+    echo '  --restore                 restores the jdtls backup'
 }
 
 function install_lombok {


### PR DESCRIPTION
Does what #6 says, specify jdtls version with `jdtls --install [version]`

Example: `jdtls -i 1.15.0`
If it cannot find it, fails with an error message:
```
λ ~/ jdtls -i 0.0.1337 

Finding jdtls:0.0.1337 

ERROR: curl http://download.eclipse.org/jdtls/milestones/0.0.1337/latest.txt failed. Are you sure that version exists? 
```

As of right now (2022-09-14), should work for versions from 1.0.0 to 1.15.0,
it tries to find them at: 
https://download.eclipse.org/jdtls/milestones/


PS: If you're using neovim with lspconfig jdtls, downgrading from 1.16.0 to 1.14.0 might fix some very annoying LSP warnings & errors.
